### PR TITLE
Allow option to load panel on click instead of on page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ panel 'Name', class: 'async-panel', 'data-url' => some_action_admin_resources_pa
 
 If you setup `data-period`, panel will be periodically updated. If not, it will be loaded once right after page load
 
+If you set `data-clickable` to a truthy value, the panel will not be loaded upon initial page load. Instead, the panel will load upon clicking the panel header. Upon page load, the panel header will have a label of 'Click to Load'. Example:
+
+```ruby
+panel 'Name', class: 'async-panel', 'data-url' => some_action_admin_resources_path, 'data-clickable' => 1
+```
+
 ### Step 2. Define action 
 
 Define `member_action` or `collection_action` to handle request specified by path helper

--- a/app/assets/javascripts/activeadmin-async_panel.js.coffee
+++ b/app/assets/javascripts/activeadmin-async_panel.js.coffee
@@ -19,6 +19,7 @@
 $ ->
   $('.async-panel').each (index, item) ->
     item = $(item)
+    requiresClick = !!item.data('clickable')
     worker = ->
       item.addClass('processing')
       $('h3', item).hide().show(0)
@@ -37,4 +38,12 @@ $ ->
           if period
             setTimeout worker, period * 1000
 
-    worker()
+    registerHandler = ->
+      item.addClass('clickable')
+      $('h3', item).on 'click', ->
+        worker()
+
+    if requiresClick
+      registerHandler()
+    else
+      worker()

--- a/app/assets/stylesheets/activeadmin-async_panel.scss.erb
+++ b/app/assets/stylesheets/activeadmin-async_panel.scss.erb
@@ -4,3 +4,23 @@
     background-size: 27px;
   }
 }
+.async-panel.panel.clickable {
+  h3 {
+    &:hover {
+      cursor: pointer;
+    }
+
+    &::after {
+      position: absolute;
+      content: 'Click to Load';
+      top: 0;
+      right: 0;
+      display: block;
+      padding: 0.25rem 0.5rem;
+      background-image: linear-gradient(180deg, #fff, #E7E7E7);
+      cursor: pointer;
+      border-top-left-radius: 1rem;
+      border-bottom-left-radius: 1rem;
+    }
+  }
+}


### PR DESCRIPTION
We have some pretty expensive panels that would be nice to only load on request. This option allows the panel to default to an unloaded state, loading upon click of the header. Preview:
<img width="196" alt="Screen Shot 2019-11-11 at 13 12 38" src="https://user-images.githubusercontent.com/2358584/68613985-94183f80-0485-11ea-8396-ac94c20d3e4f.png">
