### PR TITLE
fix:usr: Remove clickable class/button once clicked

### DIFF
--- a/app/assets/javascripts/activeadmin-async_panel.js.coffee
+++ b/app/assets/javascripts/activeadmin-async_panel.js.coffee
@@ -41,6 +41,7 @@ $ ->
     registerHandler = ->
       item.addClass('clickable')
       $('h3', item).on 'click', ->
+        $('h3', item).off('click')
         item.removeClass('clickable')
         worker()
 

--- a/app/assets/javascripts/activeadmin-async_panel.js.coffee
+++ b/app/assets/javascripts/activeadmin-async_panel.js.coffee
@@ -41,6 +41,7 @@ $ ->
     registerHandler = ->
       item.addClass('clickable')
       $('h3', item).on 'click', ->
+        item.removeClass('clickable')
         worker()
 
     if requiresClick


### PR DESCRIPTION
This is a slight fix to remove the 'Click to Load' button and click handler from the panel heading once clicked.